### PR TITLE
Fix to work in Python 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ htmlcov
 *~
 
 *.sqlite
+\.idea/

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setuptools.setup(name='devpy',
                  classifiers=['Development Status :: 1 - Planning',
                               'Intended Audience :: Developers',
                               'Natural Language :: English',
+                              'Programming Language :: Python :: 3.5',
                               'Programming Language :: Python :: 3.6',
                               'Programming Language :: Python :: 3 :: Only',
                               'Operating System :: OS Independent'],)

--- a/src/devpy/__init__.py
+++ b/src/devpy/__init__.py
@@ -1,10 +1,9 @@
-
 import devpy
 
 from .log import autolog  # noqa
 from .tb import color_traceback  # noqa
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 
 
 def dev_mode(color_traceback=True, autolog=True):  # noqa

--- a/src/devpy/develop/__init__.py
+++ b/src/devpy/develop/__init__.py
@@ -2,5 +2,4 @@ import sys
 
 from devpy import dev_mode
 
-
 sys.modules['devpy.develop'] = dev_mode()

--- a/src/devpy/log.py
+++ b/src/devpy/log.py
@@ -1,13 +1,10 @@
-
+import logging
 import os
 import sys
-import logging
-
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 import colorlog
-
-from logging.handlers import RotatingFileHandler
 
 from .temp import temp_dir
 
@@ -31,7 +28,6 @@ def autolog(
     color_log=DEFAULT_COLOR_LOG,
     _cache={}
 ):
-
     if not name:
         try:
             name = Path(sys.argv[0]).absolute().with_suffix('').name
@@ -52,7 +48,7 @@ def autolog(
     formatter = logging.Formatter(
         '%(asctime)s :: %(levelname)s :: %(pathname)s:%(lineno)s :: %(message)s'
     )
-    file_handler = RotatingFileHandler(log_file, 'a', 1000000, 1)
+    file_handler = RotatingFileHandler(str(log_file), 'a', 1000000, 1)
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
     filelogger.addHandler(file_handler)

--- a/src/devpy/tb.py
+++ b/src/devpy/tb.py
@@ -1,23 +1,20 @@
-
 import re
-import sys
 import site
-import traceback
+import sys
 import sysconfig
+import traceback
 
 import pygments.lexers
-
 from colored_traceback.colored_traceback import Colorizer
 
 LIB_DIRS = [sysconfig.get_path('stdlib'), site.USER_SITE, 'File "<frozen']
 if hasattr(sys, 'real_prefix'):
     LIB_DIRS.append(sys.prefix)
     LIB_DIRS.append(sysconfig.get_path('stdlib')
-                             .replace(sys.prefix, sys.real_prefix))
+                    .replace(sys.prefix, sys.real_prefix))
 
 
 def color_traceback(previous_hook=None):
-
     previous_hook = sys.excepthook
 
     def on_crash(type, value, tb):
@@ -31,7 +28,6 @@ def color_traceback(previous_hook=None):
 
 
 class CustomColorizer(Colorizer):
-
     def colorize_traceback(self, type, value, tb):
 
         rows = traceback.format_exception(type, value, tb)


### PR DESCRIPTION
I arranged the import order and I cleaned a few lines from the file log.py
RotatingFileHandler will crash if you don't pass a string object in the fisrt parameter.

I liked your python package and wanted to help it run on Python3.5 as well. 

:smile: :snake: 