### PR TITLE
Fix devpy erros for working on windows

### DIFF
--- a/src/devpy/log.py
+++ b/src/devpy/log.py
@@ -52,7 +52,10 @@ def autolog(
     formatter = logging.Formatter(
         '%(asctime)s :: %(levelname)s :: %(pathname)s:%(lineno)s :: %(message)s'
     )
-    file_handler = RotatingFileHandler(log_file, 'a', 1000000, 1)
+    if os.name == "nt":
+        file_handler = RotatingFileHandler(str(log_file), 'a', 1000000, 1)
+    else:
+        file_handler = RotatingFileHandler(log_file, 'a', 1000000, 1)
     file_handler.setFormatter(formatter)
     logger.addHandler(file_handler)
     filelogger.addHandler(file_handler)

--- a/src/devpy/temp.py
+++ b/src/devpy/temp.py
@@ -1,4 +1,6 @@
+import os
 import tempfile
+from contextlib import suppress
 
 from pathlib import Path
 
@@ -6,5 +8,9 @@ from pathlib import Path
 def temp_dir(name, root=None):
     root = root or tempfile.gettempdir()
     directory = Path(root) / name
-    directory.mkdir(exist_ok=True)
+    if os.name == 'nt':
+        with suppress(FileExistsError):
+            directory.mkdir()
+    else:
+        directory.mkdir(exist_ok=True)
     return directory


### PR DESCRIPTION
C:\Users\...\Desktop\doker\oscaro\env\Scripts\python.exe C:/Users/.../.../config/test/test.py

TypeError: mkdir() got an unexpected keyword argument 'exist_ok' cause from this redefined function for WindowsPath :

mkdir(mode=511, parents=False) method of pathlib.WindowsPath instance

> Traceback (most recent call last):
>   File "C:/Users/.../.../config/test/test.py", line 1, in <module>
>     import devpy.develop as log
>   File "C:\Users\...\Desktop\doker\oscaro\env\lib\site-packages\devpy\develop\__init__.py", line 6, in <module>
>     sys.modules['devpy.develop'] = dev_mode()
>   File "C:\Users\...\Desktop\doker\oscaro\env\lib\site-packages\devpy\__init__.py", line 14, in dev_mode
>     return devpy.autolog()
>   File "C:\Users\...\Desktop\doker\oscaro\env\lib\site-packages\devpy\log.py", line 50, in autolog
>     log_file = path or Path(temp_dir(name)) / "auto.log"
>   File "C:\Users\...\Desktop\doker\oscaro\env\lib\site-packages\devpy\temp.py", line 10, in temp_dir
>     directory.mkdir(exist_ok=True)
> TypeError: mkdir() got an unexpected keyword argument 'exist_ok'
> 
> Process finished with exit code 1

TypeError: 'WindowsPath' does not support the buffer interface, pass str(WindowsPath instance) to  RotatingFileHandler:
    file_handler = RotatingFileHandler(str(log_file), 'a', 1000000, 1)

C:\Users\...\Desktop\doker\oscaro\env\Scripts\python.exe C:/Users/.../.../config/test/test.py

> Traceback (most recent call last):
>   File "C:/Users/.../.../config/test/test.py", line 1, in <module>
>     import devpy.develop as log
>   File "C:\Users\...\Desktop\doker\oscaro\env\lib\site-packages\devpy\develop\__init__.py", line 6, in <module>
>     sys.modules['devpy.develop'] = dev_mode()
>   File "C:\Users\...\Desktop\doker\oscaro\env\lib\site-packages\devpy\__init__.py", line 14, in dev_mode
>     return devpy.autolog()
>   File "C:\Users\...\Desktop\doker\oscaro\env\lib\site-packages\devpy\log.py", line 55, in autolog
>     file_handler = RotatingFileHandler(log_file, 'a', 1000000, 1)
>   File "C:\Python34\Lib\logging\handlers.py", line 150, in __init__
>     BaseRotatingHandler.__init__(self, filename, mode, encoding, delay)
>   File "C:\Python34\Lib\logging\handlers.py", line 57, in __init__
>     logging.FileHandler.__init__(self, filename, mode, encoding, delay)
>   File "C:\Python34\Lib\logging\__init__.py", line 996, in __init__
>     self.baseFilename = os.path.abspath(filename)
>   File "C:\Users\...\Desktop\doker\oscaro\env\lib\ntpath.py", line 547, in abspath
>     path = _getfullpathname(path)
> TypeError: 'WindowsPath' does not support the buffer interface
> 
> Process finished with exit code 1
> 